### PR TITLE
Update core.cljc

### DIFF
--- a/src/clojure_turtle/core.cljc
+++ b/src/clojure_turtle/core.cljc
@@ -209,6 +209,14 @@
      (dorun
       states#)
      (last states#)))
+   
+(defn wait
+      "Sleeps for ms miliseconds. Can be used in a repeat to show commands execute in real time"
+      ([ms]
+      (letfn [(get-time []
+        (System/currentTimeMillis))]
+        (let [initial-time (get-time)]
+           (while (< (get-time) (+ initial-time ms)))))))
 
 (defn clean
   "Clear the lines state, which effectively clears the drawing canvas."


### PR DESCRIPTION
Added a (wait [ms]) function that takes a number of milliseconds and sleeps for that long. Can be used in a repeat loop to show steps execute in real time.
