### PR TITLE
Cljs macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Then, in your browser, visit the URL in the terminal output from the command -- 
 
 ```
 cljs.user=> (ns clojure-turtle.core)
+cljs.user=> (require '[clojure-turtle.macros :refer-macros [repeat all]])
 ```
 
 Now, the above Logo/`clojure-turtle` commands can be issued in the CLJS REPL as described above, with the result visible in the Figwheel-connected browser page.

--- a/project.clj
+++ b/project.clj
@@ -15,13 +15,15 @@
                  [org.clojure/clojurescript "1.7.170"]
                  [quil "2.2.6"]]
 
+  :source-paths ["src/cljc" "src/cljs"]
+
   :profiles {:dev {:plugins [[lein-figwheel "0.5.0-6"]
                              [lein-cljsbuild "1.1.2"]]
                    :resource-paths ["demo/public"]
                    :cljsbuild
                    {:builds
                     [{:id "dev"
-                      :source-paths ["src" "demo/src"]
+                      :source-paths ["src/cljc" "src/cljs" "demo/src"]
                       :figwheel {}
                       :compiler {:main "clojure-turtle.demo"
                                  :source-map true

--- a/src/cljc/clojure_turtle/core.cljc
+++ b/src/cljc/clojure_turtle/core.cljc
@@ -14,8 +14,11 @@
 
 (ns clojure-turtle.core
   (:refer-clojure :exclude [repeat])
-  (:require #?(:clj [quil.core :as q]
-               :cljs [quil.core :as q :include-macros true])))
+  #?(:clj
+     (:require [quil.core :as q])
+     :cljs
+     (:require [quil.core :as q :include-macros true]
+               [clojure-turtle.macros :refer-macros [repeat all]])))
 
 ;;
 ;; constants
@@ -191,23 +194,25 @@
                    (update-in [:commands] conj [:end-fill])))]
        (alter-turtle turt-state alter-fn))))
 
-(defmacro all
-  "This macro was created to substitute for the purpose served by the square brackets in Logo
+#?(:clj
+   (defmacro all
+     "This macro was created to substitute for the purpose served by the square brackets in Logo
   in a call to REPEAT.  This macro returns a no-argument function that, when invoked, executes
   the commands described in the body inside the macro call/form.
   (Haskell programmers refer to the type of function returned a 'thunk'.)"
-  [& body]
-  `(fn []
-     (do
-       ~@ body)))
+     [& body]
+     `(fn []
+        (do
+          ~@ body))))
 
-(defmacro repeat
-  "A macro to translate the purpose of the Logo REPEAT function."
-  [n & body] 
-  `(let [states# (repeatedly ~n ~@body)]
-     (dorun
-      states#)
-     (last states#)))
+#?(:clj
+   (defmacro repeat
+     "A macro to translate the purpose of the Logo REPEAT function."
+     [n & body] 
+     `(let [states# (repeatedly ~n ~@body)]
+        (dorun
+         states#)
+        (last states#))))
 
 (defn clean
   "Clear the lines state, which effectively clears the drawing canvas."

--- a/src/cljs/clojure_turtle/macros.cljc
+++ b/src/cljs/clojure_turtle/macros.cljc
@@ -1,0 +1,20 @@
+(ns clojure-turtle.macros
+  (:refer-clojure :exclude [repeat]))
+
+(defmacro all
+  "This macro was created to substitute for the purpose served by the square brackets in Logo
+  in a call to REPEAT.  This macro returns a no-argument function that, when invoked, executes
+  the commands described in the body inside the macro call/form.
+  (Haskell programmers refer to the type of function returned a 'thunk'.)"
+  [& body]
+  `(fn []
+     (do
+       ~@ body)))
+
+(defmacro repeat
+  "A macro to translate the purpose of the Logo REPEAT function."
+  [n & body]
+  `(let [states# (repeatedly ~n ~@body)]
+     (dorun
+      states#)
+     (last states#)))


### PR DESCRIPTION
This allows the `repeat` and `all` macro's to be used inside the `clojure-turtle.core` namespace. See #15 

Note: cljc and cljs classpaths had to be divided, I believe this is good practice so clojurescript code is not included during clojure compile.
